### PR TITLE
Bump deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,9 @@ edition = "2018"
 [dependencies]
 subtle = "2.0"
 thiserror = "1.0"
-zeroize = "0.6"
+zeroize = { version = "1.3", features = ["zeroize_derive"] }
 
 [dev-dependencies]
-base64 = "0.10"
-rand = "0.6"
+base64 = "0.13"
+rand = "0.8"
 serde_json = "1.0"
-
-[profile.release]
-incremental = false
-lto = true
-opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,10 @@ zeroize = { version = "1.3", features = ["zeroize_derive"] }
 
 [dev-dependencies]
 base64 = "0.13"
+criterion = "0.3"
 rand = "0.8"
 serde_json = "1.0"
+
+[[bench]]
+name = "mrae"
+harness = false

--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,11 @@ release:
 
 test:
 	@printf "$(CYAN)*** Running tests...$(OFF)\n"
-	@cargo test -- tests::test_
+	@cargo test
 
 bench:
 	@printf "$(CYAN)*** Running benchmarks...$(OFF)\n"
-	@cargo bench -- tests::bench_
+	@cargo bench
 
 fmt:
 	@printf "$(CYAN)*** Formatting code...$(OFF)\n"

--- a/benches/mrae.rs
+++ b/benches/mrae.rs
@@ -1,0 +1,76 @@
+use deoxysii::{DeoxysII, KEY_SIZE, NONCE_SIZE};
+
+use criterion::{black_box, criterion_group, criterion_main, Bencher, Criterion};
+use rand::{rngs::OsRng, RngCore};
+
+fn mrae_seal_4096(b: &mut Bencher) {
+    let mut rng = OsRng;
+
+    // Set up the key.
+    let mut key = [0u8; KEY_SIZE];
+    rng.fill_bytes(&mut key);
+    let d2 = DeoxysII::new(&key);
+
+    // Set up the payload.
+    let mut nonce = [0u8; NONCE_SIZE];
+    rng.fill_bytes(&mut nonce);
+    let mut text = [0u8; 4096];
+    rng.fill_bytes(&mut text);
+    let mut aad = [0u8; 64];
+    rng.fill_bytes(&mut aad);
+
+    // Benchmark sealing.
+    b.iter(|| {
+        let text = text.to_vec();
+        let aad = aad.to_vec();
+        let _sealed = black_box(d2.seal(&nonce, text, aad));
+    });
+}
+
+fn mrae_open_4096(b: &mut Bencher) {
+    let mut rng = OsRng;
+
+    // Set up the key.
+    let mut key = [0u8; KEY_SIZE];
+    rng.fill_bytes(&mut key);
+    let d2 = DeoxysII::new(&key);
+
+    // Set up the payload.
+    let mut nonce = [0u8; NONCE_SIZE];
+    rng.fill_bytes(&mut nonce);
+    let mut text = [0u8; 4096];
+    rng.fill_bytes(&mut text);
+    let mut aad = [0u8; 64];
+    rng.fill_bytes(&mut aad);
+
+    // Seal the payload.
+    let ciphertext = d2.seal(&nonce, text.to_vec(), aad.to_vec());
+
+    // Benchmark opening.
+    b.iter(|| {
+        let ct = ciphertext.to_vec();
+        let aad = aad.to_vec();
+        let _opened = black_box(d2.open(&nonce, ct, aad));
+    });
+}
+
+fn mrae_new(b: &mut Bencher) {
+    let mut rng = OsRng;
+
+    // Set up the key.
+    let mut key = [0u8; KEY_SIZE];
+    rng.fill_bytes(&mut key);
+
+    b.iter(|| {
+        let _d2 = black_box(DeoxysII::new(&key));
+    });
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("mrae_open_4096", mrae_open_4096);
+    c.bench_function("mrae_seal_4096", mrae_seal_4096);
+    c.bench_function("mrae_new", mrae_new);
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ use core::arch::x86_64::{
 };
 use subtle::ConstantTimeEq as _;
 use thiserror::Error;
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::Zeroize as _;
 
 include!("constants.rs");
 include!("primitives.rs");
@@ -53,22 +53,13 @@ pub enum DecryptionError {
 ///
 /// We don't store the key itself, but only components derived from the key.
 /// These components are automatically erased after the structure is dropped.
-#[derive(ZeroizeOnDrop)]
+#[derive(zeroize::Zeroize)]
 #[repr(align(16))]
+#[zeroize(drop)]
 pub struct DeoxysII {
     /// Derived K components for the sub-tweak keys for each round.
     /// These are derived from the key.
     derived_ks: [[u8; STK_SIZE]; STK_COUNT],
-}
-
-impl Zeroize for DeoxysII {
-    /// Make sure the derived K components are erased before the struct
-    /// is dropped, as they contain sensitive information.
-    fn zeroize(&mut self) {
-        for i in 0..STK_COUNT {
-            self.derived_ks[i].zeroize();
-        }
-    }
 }
 
 macro_rules! process_blocks {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,12 +28,16 @@ compile_error!("The following target_feature flags must be set: +aes,+ssse3.");
 
 extern crate alloc;
 
+#[cfg(test)]
+mod tests;
+
 use alloc::vec::Vec;
 use core::arch::x86_64::{
     __m128i, _mm_aesenc_si128, _mm_and_si128, _mm_load_si128, _mm_loadu_si128, _mm_or_si128,
     _mm_set1_epi8, _mm_set_epi64x, _mm_set_epi8, _mm_shuffle_epi8, _mm_slli_epi64, _mm_srli_epi64,
     _mm_store_si128, _mm_storeu_si128, _mm_xor_si128,
 };
+
 use subtle::ConstantTimeEq as _;
 use thiserror::Error;
 use zeroize::Zeroize as _;
@@ -360,5 +364,3 @@ impl DeoxysII {
         );
     }
 }
-
-include!("tests.rs");

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -20,218 +20,141 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#[cfg(test)]
-mod tests {
-    extern crate base64;
-    extern crate rand;
-    extern crate serde_json;
-    extern crate test;
+use super::*;
 
-    use self::{
-        base64::decode,
-        rand::{rngs::OsRng as TheRng, RngCore},
-        serde_json::{Map, Value},
-        test::{black_box, Bencher},
-    };
-    use super::*;
+use base64::decode;
+use serde_json::{Map, Value};
 
-    #[test]
-    fn test_mrae_basic() {
-        let key = [0u8; KEY_SIZE];
-        let d2 = DeoxysII::new(&key);
+#[test]
+fn test_mrae_basic() {
+    let key = [0u8; KEY_SIZE];
+    let d2 = DeoxysII::new(&key);
 
-        // Should successfully seal the text.
-        let nonce = [1u8; NONCE_SIZE];
-        let text = String::from("This is a test!").as_bytes().to_vec();
-        let aad = vec![42; 10];
-        let ciphertext = d2.seal(&nonce, text.clone(), aad.clone());
+    // Should successfully seal the text.
+    let nonce = [1u8; NONCE_SIZE];
+    let text = String::from("This is a test!").as_bytes().to_vec();
+    let aad = vec![42; 10];
+    let ciphertext = d2.seal(&nonce, text.clone(), aad.clone());
 
-        // Should successfully open the text and the text should match.
-        let opened = d2.open(&nonce, ciphertext.clone(), aad.clone());
-        assert!(opened.unwrap() == text);
+    // Should successfully open the text and the text should match.
+    let opened = d2.open(&nonce, ciphertext.clone(), aad.clone());
+    assert!(opened.unwrap() == text);
 
-        // Should fail if the nonce is different.
-        let fake_nonce = [2u8; NONCE_SIZE];
-        let fail_opened = d2.open(&fake_nonce, ciphertext.clone(), aad.clone());
-        assert!(fail_opened.is_err());
+    // Should fail if the nonce is different.
+    let fake_nonce = [2u8; NONCE_SIZE];
+    let fail_opened = d2.open(&fake_nonce, ciphertext.clone(), aad.clone());
+    assert!(fail_opened.is_err());
 
-        // Should fail if the additional data is different.
-        let fake_aad = vec![47; 10];
-        let fail_opened = d2.open(&nonce, ciphertext.clone(), fake_aad.clone());
-        assert!(fail_opened.is_err());
+    // Should fail if the additional data is different.
+    let fake_aad = vec![47; 10];
+    let fail_opened = d2.open(&nonce, ciphertext.clone(), fake_aad.clone());
+    assert!(fail_opened.is_err());
 
-        // Should fail if the both the nonce and the additional data are different.
-        let fake_nonce = [3u8; NONCE_SIZE];
-        let fake_aad = vec![4; 5];
-        let fail_opened = d2.open(&fake_nonce, ciphertext.clone(), fake_aad.clone());
-        assert!(fail_opened.is_err());
+    // Should fail if the both the nonce and the additional data are different.
+    let fake_nonce = [3u8; NONCE_SIZE];
+    let fake_aad = vec![4; 5];
+    let fail_opened = d2.open(&fake_nonce, ciphertext.clone(), fake_aad.clone());
+    assert!(fail_opened.is_err());
 
-        // Should handle too short ciphertext.
-        let fail_opened = d2.open(&nonce, vec![1, 2, 3], aad.clone());
-        assert!(fail_opened.is_err());
+    // Should handle too short ciphertext.
+    let fail_opened = d2.open(&nonce, vec![1, 2, 3], aad.clone());
+    assert!(fail_opened.is_err());
 
-        // Should fail on damaged ciphertext.
-        let mut malformed_ciphertext = ciphertext.clone();
-        malformed_ciphertext[3] ^= 0xa5;
-        let fail_opened = d2.open(&nonce, malformed_ciphertext, aad.clone());
-        assert!(fail_opened.is_err());
+    // Should fail on damaged ciphertext.
+    let mut malformed_ciphertext = ciphertext.clone();
+    malformed_ciphertext[3] ^= 0xa5;
+    let fail_opened = d2.open(&nonce, malformed_ciphertext, aad.clone());
+    assert!(fail_opened.is_err());
 
-        // Should fail on truncated ciphertext.
-        let mut truncated_ciphertext = ciphertext.clone();
-        truncated_ciphertext.truncate(ciphertext.len() - 5);
-        let fail_opened = d2.open(&nonce, truncated_ciphertext, aad.clone());
-        assert!(fail_opened.is_err());
+    // Should fail on truncated ciphertext.
+    let mut truncated_ciphertext = ciphertext.clone();
+    truncated_ciphertext.truncate(ciphertext.len() - 5);
+    let fail_opened = d2.open(&nonce, truncated_ciphertext, aad.clone());
+    assert!(fail_opened.is_err());
+}
+
+#[test]
+fn test_mrae_nonblocksized() {
+    let key = [42u8; KEY_SIZE];
+    let d2 = DeoxysII::new(&key);
+
+    // Should successfully seal msg with non-block-sized additional data.
+    let nonce = [7u8; NONCE_SIZE];
+    let mut text = Vec::with_capacity(BLOCK_SIZE * 7 + 3);
+    for i in 0..text.capacity() {
+        text.push(i as u8);
     }
-
-    #[test]
-    fn test_mrae_nonblocksized() {
-        let key = [42u8; KEY_SIZE];
-        let d2 = DeoxysII::new(&key);
-
-        // Should successfully seal msg with non-block-sized additional data.
-        let nonce = [7u8; NONCE_SIZE];
-        let mut text = Vec::with_capacity(BLOCK_SIZE * 7 + 3);
-        for i in 0..text.capacity() {
-            text.push(i as u8);
-        }
-        let mut aad = Vec::with_capacity(BLOCK_SIZE + 5);
-        for i in 0..aad.capacity() {
-            aad.push(i as u8);
-        }
-        let ciphertext = d2.seal(&nonce, text.clone(), aad.clone());
-
-        // Should successfully open the text and the text should match.
-        let opened = d2.open(&nonce, ciphertext.clone(), aad.clone());
-        assert!(opened.unwrap() == text);
+    let mut aad = Vec::with_capacity(BLOCK_SIZE + 5);
+    for i in 0..aad.capacity() {
+        aad.push(i as u8);
     }
+    let ciphertext = d2.seal(&nonce, text.clone(), aad.clone());
 
-    #[test]
-    fn test_mrae_blocksized() {
-        let key = [42u8; KEY_SIZE];
-        let d2 = DeoxysII::new(&key);
+    // Should successfully open the text and the text should match.
+    let opened = d2.open(&nonce, ciphertext.clone(), aad.clone());
+    assert!(opened.unwrap() == text);
+}
 
-        // Should successfully seal msg with block-sized additional data.
-        let nonce = [7u8; NONCE_SIZE];
-        let mut text = Vec::with_capacity(BLOCK_SIZE * 8);
-        for i in 0..text.capacity() {
-            text.push(i as u8);
-        }
-        let mut aad = Vec::with_capacity(BLOCK_SIZE);
-        for i in 0..aad.capacity() {
-            aad.push(i as u8);
-        }
-        let ciphertext = d2.seal(&nonce, text.clone(), aad.clone());
+#[test]
+fn test_mrae_blocksized() {
+    let key = [42u8; KEY_SIZE];
+    let d2 = DeoxysII::new(&key);
 
-        // Should successfully open the text and the text should match.
-        let opened = d2.open(&nonce, ciphertext.clone(), aad.clone());
-        assert!(opened.unwrap() == text);
+    // Should successfully seal msg with block-sized additional data.
+    let nonce = [7u8; NONCE_SIZE];
+    let mut text = Vec::with_capacity(BLOCK_SIZE * 8);
+    for i in 0..text.capacity() {
+        text.push(i as u8);
     }
-
-    #[test]
-    fn test_mrae_vectors() {
-        let test_vectors = include_str!("../test-data/Deoxys-II-256-128.json");
-        let test_vectors: Map<String, Value> = serde_json::from_str(test_vectors).unwrap();
-
-        let key_vec = decode(test_vectors["Key"].as_str().unwrap())
-            .unwrap()
-            .to_vec();
-        let msg = decode(test_vectors["MsgData"].as_str().unwrap())
-            .unwrap()
-            .to_vec();
-        let aad = decode(test_vectors["AADData"].as_str().unwrap())
-            .unwrap()
-            .to_vec();
-        let nonce_vec = decode(test_vectors["Nonce"].as_str().unwrap())
-            .unwrap()
-            .to_vec();
-
-        let mut key = [0u8; KEY_SIZE];
-        let mut nonce = [0u8; NONCE_SIZE];
-        key.copy_from_slice(&key_vec);
-        nonce.copy_from_slice(&nonce_vec);
-
-        let d2 = DeoxysII::new(&key);
-
-        for v in test_vectors["KnownAnswers"].as_array().unwrap().iter() {
-            let ciphertext = decode(v["Ciphertext"].as_str().unwrap()).unwrap().to_vec();
-            let tag = decode(v["Tag"].as_str().unwrap()).unwrap().to_vec();
-            let length: usize = v["Length"].as_u64().unwrap() as usize;
-
-            let ct = d2.seal(&nonce, msg[..length].to_vec(), aad[..length].to_vec());
-
-            assert_eq!(ct.len(), length + TAG_SIZE);
-
-            let t = ct[length..].to_vec();
-            let ct = ct[..length].to_vec();
-
-            assert_eq!(ciphertext, ct);
-            assert_eq!(tag, t);
-        }
+    let mut aad = Vec::with_capacity(BLOCK_SIZE);
+    for i in 0..aad.capacity() {
+        aad.push(i as u8);
     }
+    let ciphertext = d2.seal(&nonce, text.clone(), aad.clone());
 
-    #[bench]
-    fn bench_mrae_seal_4096(b: &mut Bencher) {
-        let mut rng = TheRng::new().unwrap();
+    // Should successfully open the text and the text should match.
+    let opened = d2.open(&nonce, ciphertext.clone(), aad.clone());
+    assert!(opened.unwrap() == text);
+}
 
-        // Set up the key.
-        let mut key = [0u8; KEY_SIZE];
-        rng.fill_bytes(&mut key);
-        let d2 = DeoxysII::new(&key);
+#[test]
+fn test_mrae_vectors() {
+    let test_vectors = include_str!("../test-data/Deoxys-II-256-128.json");
+    let test_vectors: Map<String, Value> = serde_json::from_str(test_vectors).unwrap();
 
-        // Set up the payload.
-        let mut nonce = [0u8; NONCE_SIZE];
-        rng.fill_bytes(&mut nonce);
-        let mut text = [0u8; 4096];
-        rng.fill_bytes(&mut text);
-        let mut aad = [0u8; 64];
-        rng.fill_bytes(&mut aad);
+    let key_vec = decode(test_vectors["Key"].as_str().unwrap())
+        .unwrap()
+        .to_vec();
+    let msg = decode(test_vectors["MsgData"].as_str().unwrap())
+        .unwrap()
+        .to_vec();
+    let aad = decode(test_vectors["AADData"].as_str().unwrap())
+        .unwrap()
+        .to_vec();
+    let nonce_vec = decode(test_vectors["Nonce"].as_str().unwrap())
+        .unwrap()
+        .to_vec();
 
-        // Benchmark sealing.
-        b.iter(|| {
-            let text = text.to_vec();
-            let aad = aad.to_vec();
-            let _sealed = black_box(d2.seal(&nonce, text, aad));
-        });
-    }
+    let mut key = [0u8; KEY_SIZE];
+    let mut nonce = [0u8; NONCE_SIZE];
+    key.copy_from_slice(&key_vec);
+    nonce.copy_from_slice(&nonce_vec);
 
-    #[bench]
-    fn bench_mrae_open_4096(b: &mut Bencher) {
-        let mut rng = TheRng::new().unwrap();
+    let d2 = DeoxysII::new(&key);
 
-        // Set up the key.
-        let mut key = [0u8; KEY_SIZE];
-        rng.fill_bytes(&mut key);
-        let d2 = DeoxysII::new(&key);
+    for v in test_vectors["KnownAnswers"].as_array().unwrap().iter() {
+        let ciphertext = decode(v["Ciphertext"].as_str().unwrap()).unwrap().to_vec();
+        let tag = decode(v["Tag"].as_str().unwrap()).unwrap().to_vec();
+        let length: usize = v["Length"].as_u64().unwrap() as usize;
 
-        // Set up the payload.
-        let mut nonce = [0u8; NONCE_SIZE];
-        rng.fill_bytes(&mut nonce);
-        let mut text = [0u8; 4096];
-        rng.fill_bytes(&mut text);
-        let mut aad = [0u8; 64];
-        rng.fill_bytes(&mut aad);
+        let ct = d2.seal(&nonce, msg[..length].to_vec(), aad[..length].to_vec());
 
-        // Seal the payload.
-        let ciphertext = d2.seal(&nonce, text.to_vec(), aad.to_vec());
+        assert_eq!(ct.len(), length + TAG_SIZE);
 
-        // Benchmark opening.
-        b.iter(|| {
-            let ct = ciphertext.to_vec();
-            let aad = aad.to_vec();
-            let _opened = black_box(d2.open(&nonce, ct, aad));
-        });
-    }
+        let t = ct[length..].to_vec();
+        let ct = ct[..length].to_vec();
 
-    #[bench]
-    fn bench_mrae_new(b: &mut Bencher) {
-        let mut rng = TheRng::new().unwrap();
-
-        // Set up the key.
-        let mut key = [0u8; KEY_SIZE];
-        rng.fill_bytes(&mut key);
-
-        b.iter(|| {
-            let _d2 = black_box(DeoxysII::new(&key));
-        });
+        assert_eq!(ciphertext, ct);
+        assert_eq!(tag, t);
     }
 }


### PR DESCRIPTION
This PR bumps the crate dependencies, most notably zeroize which has now [yanked all pre-1.0 versions](https://crates.io/crates/zeroize/versions) (i.e. this crate now doesn't work). The PR also uses [the criterion crate](https://crates.io/crates/criterion) because `cargo-bench` isn't staying around.