### PR TITLE
Use asm! instead of llvm_asm!, which no longer exists

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 //! Deoxys-II-256-128 MRAE primitive implementation.
-#![feature(llvm_asm, test)]
+#![feature(asm, test)]
 
 #[cfg(not(all(target_feature = "aes", target_feature = "ssse3",)))]
 compile_error!("The following target_feature flags must be set: +aes,+ssse3.");

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -327,26 +327,42 @@ fn sanitize_xmm_registers() {
         // This is overly heavy handed, but the downside to using intrinsics
         // is that there's no way to tell which registers end up with sensitive
         // key material.
-        llvm_asm!("pxor %xmm0, %xmm0
-            pxor %xmm1, %xmm1
-            pxor %xmm2, %xmm2
-            pxor %xmm3, %xmm3
-            pxor %xmm4, %xmm4
-            pxor %xmm5, %xmm5
-            pxor %xmm6, %xmm6
-            pxor %xmm7, %xmm7
-            pxor %xmm8, %xmm8
-            pxor %xmm9, %xmm9
-            pxor %xmm10, %xmm10
-            pxor %xmm11, %xmm11
-            pxor %xmm12, %xmm12
-            pxor %xmm13, %xmm13
-            pxor %xmm14, %xmm14
-            pxor %xmm15, %xmm15"
-            :
-            :
-            :"xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5", "xmm6", "xmm7", "xmm8", "xmm9", "xmm10", "xmm11", "xmm12", "xmm13", "xmm14", "xmm15"
-            : "volatile"
+        std::arch::asm!(
+            "
+            pxor xmm0, xmm0
+            pxor xmm1, xmm1
+            pxor xmm2, xmm2
+            pxor xmm3, xmm3
+            pxor xmm4, xmm4
+            pxor xmm5, xmm5
+            pxor xmm6, xmm6
+            pxor xmm7, xmm7
+            pxor xmm8, xmm8
+            pxor xmm9, xmm9
+            pxor xmm10, xmm10
+            pxor xmm11, xmm11
+            pxor xmm12, xmm12
+            pxor xmm13, xmm13
+            pxor xmm14, xmm14
+            pxor xmm15, xmm15
+            ",
+            lateout("xmm0") _,
+            lateout("xmm1") _,
+            lateout("xmm2") _,
+            lateout("xmm3") _,
+            lateout("xmm4") _,
+            lateout("xmm5") _,
+            lateout("xmm6") _,
+            lateout("xmm7") _,
+            lateout("xmm8") _,
+            lateout("xmm9") _,
+            lateout("xmm10") _,
+            lateout("xmm11") _,
+            lateout("xmm12") _,
+            lateout("xmm13") _,
+            lateout("xmm14") _,
+            lateout("xmm15") _,
+            options(nostack)
         );
     }
 }


### PR DESCRIPTION
[docs for `asm!`](https://doc.rust-lang.org/unstable-book/library-features/asm.html)